### PR TITLE
Create SOMtoday tokens table

### DIFF
--- a/app/Models/SomtodayProfile.php
+++ b/app/Models/SomtodayProfile.php
@@ -25,4 +25,9 @@ class SomtodayProfile extends Model
     {
         return $this->hasMany(SomtodayAbsentie::class);
     }
+
+    public function token()
+    {
+        return $this->hasOne(SomtodayToken::class);
+    }
 }

--- a/app/Models/SomtodayToken.php
+++ b/app/Models/SomtodayToken.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class SomtodayToken extends Model
+{
+    use HasFactory;
+
+    public function profile()
+    {
+        return $this->belongsTo(SomtodayProfile::class);
+    }
+}

--- a/database/migrations/2022_08_19_144627_create_somtoday_tokens_table.php
+++ b/database/migrations/2022_08_19_144627_create_somtoday_tokens_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('somtoday_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+
+            $table->bigInteger('profile_id', false, true)->unsigned()->index();
+
+            $table->string('access_token');
+            $table->string('refresh_token');
+            $table->string('somtoday_api_url');
+            $table->string('somtoday_oop_url');
+            $table->string('somtoday_tenant');
+            $table->string('id_token');
+            $table->unsignedBigInteger('expires_in');
+
+            $table->foreign('profile_id')->references('id')->on('somtoday_profiles')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('somtoday_tokens');
+    }
+};


### PR DESCRIPTION
This PR adds a SOMtoday tokens table to the artisan migrations, and also has a model with a relationship to SomtodayProfile. This is because we didn't have a way to store SOMtoday token information.